### PR TITLE
Fixed Dockerfile and README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM debian
 RUN apt update && apt install -y ca-certificates lynx
-ENTRYPOINT ["lynx","--useragent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_0) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.79 Safari/537.1 Lynx\""]
 COPY lynx.lss lynx.cfg /etc/lynx/
-USER nobody
-CMD ["-h"]
+ENTRYPOINT ["lynx","--useragent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_0) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.79 Safari/537.1 Lynx\""]
 
 # The hard way:
 #

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ just my right hand (so my left can hold a cup of coffee).
 Using the Docker image above is the preferred way to get going quickly.
 But if you wish to add `lynx` to your own system consider the following.
 
-On Debian and Ubuntu `sudo update && sudo apt -y install lynx` works.
+On Debian and Ubuntu `sudo apt update && sudo apt -y install lynx` works.
 
 If for some reason you don't have the ability to change files in
 `/etc/lynx` then consider putting them in `~/.config/lynx` instead and


### PR DESCRIPTION
I modified the dockerfile as the configs weren't loading at all and removed the need for the USER and CMD commands. It will now load into rwxrob page if you don't provide any commands